### PR TITLE
Check which OpenCL library to use.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,15 @@
 # copyright 2013 Jens Schwarzer (schwarzer@schwarzer.dk)
 
+ifeq ($(shell uname), Darwin) # Apple
+    LIBOPENCL=-framework OpenCL
+else       # Linux
+    LIBOPENCL=-L$(OPENCLLIB) -lOpenCL
+endif
+
+
+
 opencl-info: opencl-info.cpp
-	g++ -Wall -std=c++11 -O3 opencl-info.cpp -oopencl-info -lOpenCL
+	g++ -Wall -std=c++11 -O3 opencl-info.cpp -oopencl-info $(LIBOPENCL)
 
 clean:
 	rm opencl-info


### PR DESCRIPTION
Seems to be required to get opencl-info working in OSX (different way of linking libraries... aka frameworks)
